### PR TITLE
Enable stemming in SearchWP settings

### DIFF
--- a/dss-wordpress-norwegian-stemmer.php
+++ b/dss-wordpress-norwegian-stemmer.php
@@ -56,6 +56,9 @@ function dss_norwegian_stopwords($terms) {
 
 add_filter( 'searchwp_common_words', 'dss_norwegian_stopwords' );
 
+// Tell SearchWP we have a stemmer
+add_filter( 'searchwp_keyword_stem_locale', '__return_true' );
+
 
 if (!function_exists('write_log')) {
     function write_log ( $log )  {


### PR DESCRIPTION
SearchWP has implemented functionality to check for a stemmer for the current locale prior to enabling the option on the settings screen. This hook tells SearchWP there is a stemmer for the current locale.